### PR TITLE
feat: let system admins permanently delete users

### DIFF
--- a/src/app/(dashboard)/system-admin/users/components/delete-user-dialog.tsx
+++ b/src/app/(dashboard)/system-admin/users/components/delete-user-dialog.tsx
@@ -11,11 +11,10 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Loader2 } from 'lucide-react'
-import { TenantUser } from '../types'
+import { GlobalUser, TenantUser } from '../types'
 
 interface DeleteUserDialogProps {
-  user: TenantUser | null
-  tenantName?: string
+  user: GlobalUser | TenantUser | null
   open: boolean
   onOpenChange: (open: boolean) => void
   onConfirm: () => Promise<void>
@@ -24,7 +23,6 @@ interface DeleteUserDialogProps {
 
 export function DeleteUserDialog({
   user,
-  tenantName,
   open,
   onOpenChange,
   onConfirm,
@@ -34,21 +32,13 @@ export function DeleteUserDialog({
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Remove user from tenant?</AlertDialogTitle>
+          <AlertDialogTitle>Delete user?</AlertDialogTitle>
           <AlertDialogDescription>
-            This removes{' '}
+            This permanently deletes{' '}
             <span className="font-medium text-foreground">{user?.name}</span>{' '}
-            (<span className="font-mono">{user?.email}</span>) from
-            {tenantName ? (
-              <>
-                {' '}
-                <span className="font-medium text-foreground">{tenantName}</span>
-              </>
-            ) : (
-              ' this tenant'
-            )}
-            . The user account itself is not deleted, but they will lose access to
-            this tenant.
+            (<span className="font-mono">{user?.email}</span>)
+            {user?.isSysAdmin ? ', including their System Admin access,' : ''}
+            {' '}and removes them from every tenant. This cannot be undone.
           </AlertDialogDescription>
         </AlertDialogHeader>
 
@@ -63,7 +53,7 @@ export function DeleteUserDialog({
             className="bg-destructive text-white hover:bg-destructive/90"
           >
             {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Remove
+            Delete
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/app/(dashboard)/system-admin/users/hooks/use-users.ts
+++ b/src/app/(dashboard)/system-admin/users/hooks/use-users.ts
@@ -290,16 +290,20 @@ export function useUsers() {
     []
   )
 
+  /**
+   * Permanently delete a user account via DELETE /api/v1/admin/users/{userId}.
+   * No tenant context required.
+   */
   const deleteUser = useCallback(
-    async (tenantId: string, userId: string): Promise<void> => {
+    async (userId: string): Promise<void> => {
       setIsMutating(true)
       try {
         const res = await fetch(
-          `${BASE_URL}/${encodeURIComponent(userId)}?tenantId=${encodeURIComponent(tenantId)}`,
+          `${BASE_URL}/${encodeURIComponent(userId)}`,
           { method: 'DELETE' }
         )
         if (!res.ok && res.status !== 204) {
-          await parseError(res, 'Failed to remove user')
+          await parseError(res, 'Failed to delete user')
         }
       } finally {
         setIsMutating(false)

--- a/src/app/(dashboard)/system-admin/users/page.tsx
+++ b/src/app/(dashboard)/system-admin/users/page.tsx
@@ -56,7 +56,7 @@ const PAGE_SIZE = 20;
 const ALL_TENANTS = '__all__';
 
 function UsersPageContent() {
-  const { isLoading: isAuthLoading } = useAuth();
+  const { user: currentUser, isLoading: isAuthLoading } = useAuth();
 
   const [selectedTenantId, setSelectedTenantId] = useState<string>(ALL_TENANTS);
   const [searchInput, setSearchInput] = useState('');
@@ -66,7 +66,7 @@ function UsersPageContent() {
 
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [detailTarget, setDetailTarget] = useState<GlobalUser | TenantUser | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<TenantUser | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<GlobalUser | TenantUser | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
   // The tenant selector needs the full tenant list, not a single page — the
@@ -188,16 +188,22 @@ function UsersPageContent() {
     }
   }
 
+  const isCurrentUser = (u: GlobalUser | TenantUser) =>
+    (!!currentUser?.id && u.userId === currentUser.id) ||
+    (!!currentUser?.email &&
+      u.email.toLowerCase() === currentUser.email.toLowerCase())
+
   const handleDeleteConfirm = async () => {
-    if (isAllTenants || !deleteTarget) return;
+    if (!deleteTarget) return;
     setIsDeleting(true);
     try {
-      await deleteUser(selectedTenantId, deleteTarget.userId);
-      toast.success(`${deleteTarget.name} removed`);
+      await deleteUser(deleteTarget.userId);
+      toast.success(`${deleteTarget.name} deleted`);
+      if (detailTarget?.userId === deleteTarget.userId) setDetailTarget(null);
       setDeleteTarget(null);
       loadUsers();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to remove user');
+      toast.error(err instanceof Error ? err.message : 'Failed to delete user');
     } finally {
       setIsDeleting(false);
     }
@@ -416,12 +422,13 @@ function UsersPageContent() {
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
                             <DropdownMenuItem
-                              onClick={() => setDeleteTarget(u as TenantUser)}
-                              disabled={isAllTenants}
+                              onClick={() => setDeleteTarget(u)}
+                              disabled={isCurrentUser(u)}
+                              title={isCurrentUser(u) ? 'You cannot delete your own account' : undefined}
                               className="text-destructive focus:text-destructive"
                             >
                               <Trash2 className="mr-2 h-4 w-4" />
-                              Remove from Tenant
+                              Delete user
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>
@@ -462,7 +469,7 @@ function UsersPageContent() {
 
       {isAllTenants && (
         <p className="text-xs text-muted-foreground text-center">
-          Showing all platform users. Select a specific tenant to add or remove users.
+          Showing all platform users. Select a specific tenant to add users.
         </p>
       )}
       </DashboardPageBody>
@@ -486,7 +493,6 @@ function UsersPageContent() {
 
       <DeleteUserDialog
         user={deleteTarget}
-        tenantName={tenantName}
         open={deleteTarget !== null}
         onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
         onConfirm={handleDeleteConfirm}

--- a/src/app/api/system-admin/users/[userId]/route.ts
+++ b/src/app/api/system-admin/users/[userId]/route.ts
@@ -15,8 +15,8 @@ import { normalizeGlobalUserDetail } from '@/app/(dashboard)/system-admin/users/
  *          rejects SysAdmin users. Role changes go through /[userId]/role instead.
  *          via PATCH /api/v1/admin/users/{userId}
  *
- * DELETE → remove user from a specific tenant (tenantId required)
- *          via DELETE /api/v1/admin/tenants/{tenantId}/users/{userId}
+ * DELETE → permanently delete the user account (including other system admins)
+ *          via DELETE /api/v1/admin/users/{userId}
  */
 
 function extractUserId(pathname: string): string | null {
@@ -24,9 +24,8 @@ function extractUserId(pathname: string): string | null {
   return match ? decodeURIComponent(match[1]) : null
 }
 
-function getTenantId(request: NextRequest): string | null {
-  const v = request.nextUrl.searchParams.get('tenantId')
-  return v && v.trim() ? v.trim() : null
+function emailsMatch(a?: string | null, b?: string | null): boolean {
+  return !!a && !!b && a.trim().toLowerCase() === b.trim().toLowerCase()
 }
 
 /**
@@ -97,28 +96,38 @@ export const PATCH = withSystemAdmin(async (request: NextRequest) => {
 })
 
 /**
- * DELETE /api/system-admin/users/[userId]?tenantId=
- * Remove the user's membership from a specific tenant. tenantId is required.
+ * DELETE /api/system-admin/users/[userId]
+ * Permanently delete the user account. Other system admins may be deleted;
+ * callers cannot delete themselves.
  */
-export const DELETE = withSystemAdmin(async (request: NextRequest) => {
+export const DELETE = withSystemAdmin(async (request: NextRequest, { session }) => {
   const userId = extractUserId(request.nextUrl.pathname)
-  const tenantId = getTenantId(request)
   if (!userId) {
     return NextResponse.json({ error: 'User ID is required' }, { status: 400 })
-  }
-  if (!tenantId) {
-    return NextResponse.json({ error: 'tenantId is required' }, { status: 400 })
   }
 
   try {
     const client = createXiansClient()
-    await client.delete(
-      `/api/v1/admin/tenants/${encodeURIComponent(tenantId)}/users/${encodeURIComponent(userId)}`
+    const target = await client.get<{ userId?: string; email?: string }>(
+      `/api/v1/admin/users/${encodeURIComponent(userId)}`
     )
+
+    if (
+      userId === session.user.id ||
+      emailsMatch(target.email, session.user.email)
+    ) {
+      return NextResponse.json(
+        { error: 'You cannot delete your own account' },
+        { status: 400 }
+      )
+    }
+
+    // DELETE /api/v1/admin/users/{userId} — permanently delete the user account
+    await client.delete(`/api/v1/admin/users/${encodeURIComponent(userId)}`)
     return new NextResponse(null, { status: 204 })
   } catch (error) {
     return handleApiError(error, 'system-admin/users/[userId] DELETE', {
-      fallbackMessage: 'Failed to remove user',
+      fallbackMessage: 'Failed to delete user',
     })
   }
 })


### PR DESCRIPTION
## Summary
- Replaces “Remove from Tenant” on `/system-admin/users` with a hard-delete action that works in All Tenants view, including other system admins.
- Proxies `DELETE /api/system-admin/users/{userId}` to `DELETE /api/v1/admin/users/{userId}` and blocks callers from deleting their own account.

## Test plan
- [ ] As a system admin, open `/system-admin/users` and confirm the row menu shows **Delete user** (not remove from tenant).
- [ ] Delete another system admin and a regular user; both should disappear after confirmation.
- [ ] Confirm your own row’s delete action is disabled.
- [ ] Confirm disable-account still uses the status endpoint and is unchanged.


Made with [Cursor](https://cursor.com)