### PR TITLE
feat(user-menu): show user ID alongside email in profile menu

### DIFF
--- a/src/components/layout/user-menu.tsx
+++ b/src/components/layout/user-menu.tsx
@@ -52,6 +52,7 @@ export function UserMenu() {
   const user = {
     name: session?.user?.name || 'User',
     email: session?.user?.email || '',
+    id: session?.user?.id || '',
     avatar: session?.user?.image || '',
     initials: session?.user?.name?.split(' ').map(n => n[0]).join('').toUpperCase() || 'U',
   }
@@ -156,7 +157,7 @@ export function UserMenu() {
         align="end"
         sideOffset={8}
         collisionPadding={12}
-        className="w-[min(16rem,calc(100vw-1rem))]"
+        className="w-[min(22rem,calc(100vw-1rem))]"
       >
         {/* Mobile: drill-down panels */}
         {isMobile && panel === 'tenants' && currentTenant && (
@@ -202,7 +203,10 @@ export function UserMenu() {
               </Avatar>
               <div className="flex flex-col flex-1 min-w-0 gap-1">
                 <p className="text-sm font-medium truncate">{user.name}</p>
-                <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+                <p className="text-xs text-muted-foreground truncate" title={user.email}>{user.email}</p>
+                {user.id && (
+                  <p className="text-xs text-muted-foreground truncate" title={user.id}>{user.id}</p>
+                )}
                 {session?.user?.isSystemAdmin && (
                   <Badge variant="secondary" className="w-fit text-[10px] px-1.5 py-0 h-4 gap-1">
                     <ShieldCheck className="h-3 w-3" />


### PR DESCRIPTION
## Summary

- Show the authenticated user's ID (`session.user.id`) on its own line beneath the email in the profile dropdown, so it can be read off directly when looking up or supporting a user.
- Widen the dropdown from 16rem to 22rem so a full 36-character GUID fits without truncation. The `min()` wrapper is unchanged, so the menu still shrinks to the viewport on narrow screens.
- Add `title` attributes to the email and ID lines as a fallback for the narrow-screen case where they still truncate.

The ID line only renders when `session.user.id` is populated, so nothing empty appears before the session hydrates.

## Test plan

- [ ] Open the profile menu and confirm the user ID appears below the email and is not cropped.
- [ ] Confirm the System Admin and tenant role badges still render below the ID.
- [ ] Check on a narrow/mobile viewport that the menu fits the screen and the "Switch tenant" drill-down still works.

Made with [Cursor](https://cursor.com)