### PR TITLE
fix(conversations): recover agent replies after an SSE drop

### DIFF
--- a/docs/implementation-notes/SSE_REAL_TIME_MESSAGING.md
+++ b/docs/implementation-notes/SSE_REAL_TIME_MESSAGING.md
@@ -72,7 +72,7 @@ Structured data messages
 ```
 
 ### `heartbeat`
-Keep-alive events (sent every ~60 seconds)
+Keep-alive events (sent every ~30 seconds; also the liveness signal for the reconnect watchdog)
 ```json
 {
   "timestamp": "2026-01-19T18:35:47.782453Z",
@@ -98,9 +98,19 @@ Keep-alive events (sent every ~60 seconds)
 - Automatically includes user's participant ID from session
 
 ### Reconnection Strategy
-- **Exponential backoff**: Starts at 1 second, doubles each attempt
-- **Max attempts**: 5 attempts before giving up
+- **Exponential backoff**: Starts at 1 second, doubles each attempt, capped at 30 seconds with jitter
+- **Max attempts**: 6 attempts, after which the hook keeps retrying once a minute
 - **Auto-reconnect**: On connection errors (not on manual close)
+- **Heartbeat watchdog**: A stream that receives nothing for 75 seconds is rebuilt even if the browser still reports it `OPEN` (sleep/wake and silently dropped proxy connections never fire an `error` event)
+- **Network/visibility triggers**: Reconnects immediately when the browser comes back online or the tab becomes visible, and skips retries entirely while `navigator.onLine` is false
+
+### Recovering Missed Messages
+A new stream replays nothing, so anything published during an outage is only
+recoverable from history. The listener exposes `onReconnect`, which the
+conversation page uses to refetch the current topic and merge it into what is on
+screen (`mergeMessagesById`). While the stream is down the page also polls
+history every 10 seconds, so an agent reply still lands even if the stream never
+recovers.
 
 ### Disconnection
 - Automatic on page unmount or navigation
@@ -128,11 +138,13 @@ Only `Outgoing` messages (from agent) are displayed in the UI. `Incoming` messag
 - **Parse errors**: Logged but don't break connection
 - **Stream errors**: Gracefully handled with cleanup
 - **Client disconnects**: Silent cleanup on server side
-- **Max reconnection attempts**: After 5 failed attempts, users are redirected to a dedicated error page
+- **Max reconnection attempts**: After 6 failed attempts on a connection that never opened, users are redirected to a dedicated error page
 
 ### Server Unavailability Handling
 
-When the SSE connection fails after maximum reconnection attempts (5 attempts with exponential backoff: 1s, 2s, 4s, 8s, 16s), users are automatically redirected to `/server-unavailable`. This page is **outside the dashboard layout** so it remains accessible even when the backend or auth fails.
+When the SSE connection never opens and the backoff ladder is exhausted (6 attempts: 1s, 2s, 4s, 8s, 16s, 30s), users are automatically redirected to `/server-unavailable`. This page is **outside the dashboard layout** so it remains accessible even when the backend or auth fails.
+
+A stream that *had* been working does not trigger the redirect: dropping a user out of a live conversation over a transient blip is worse than staying put while the background retries and history polling do their job.
 
 **Why outside dashboard?** The dashboard layout requires auth and tenant data. If placed inside `(dashboard)`, the error page would fail to load when the backend is unavailable.
 
@@ -148,7 +160,13 @@ When the SSE connection fails after maximum reconnection attempts (5 attempts wi
 ```typescript
 import { useMessageListener } from '@/hooks/use-message-listener';
 
-const { isConnected, error, maxReconnectAttemptsReached, reconnect } = useMessageListener({
+const {
+  isConnected,
+  error,
+  maxReconnectAttemptsReached,
+  hasEverConnected,
+  reconnect,
+} = useMessageListener({
   tenantId: 'tenant-123',
   agentName: 'Support Agent',
   activationName: 'Live Chat',
@@ -165,25 +183,32 @@ const { isConnected, error, maxReconnectAttemptsReached, reconnect } = useMessag
   onDisconnect: () => {
     console.log('Disconnected');
   },
+  onReconnect: () => {
+    // Nothing is replayed on a new stream - refetch history to fill the gap
+    syncTopicMessages(selectedTopicId);
+  },
 });
 
-// Redirect to error page when max attempts reached
+// Redirect to error page only when the stream never came up
 useEffect(() => {
-  if (maxReconnectAttemptsReached) {
+  if (maxReconnectAttemptsReached && !hasEverConnected) {
     router.push('/server-unavailable?error=Connection failed');
   }
-}, [maxReconnectAttemptsReached]);
+}, [maxReconnectAttemptsReached, hasEverConnected]);
 ```
 
 ## Configuration
 
 ### Heartbeat Interval
-Default: 60 seconds (configurable via `heartbeatSeconds` query parameter)
+30 seconds, sent as the `heartbeatSeconds` query parameter. Kept below common
+proxy idle timeouts so the stream is not dropped for being quiet, and it doubles
+as the liveness signal for the watchdog.
 
 ### Reconnection Settings
 - Base delay: 1000ms
-- Max attempts: 5
-- Backoff multiplier: 2x
+- Max attempts: 6, then a 60s retry loop
+- Backoff multiplier: 2x, capped at 30s, plus up to 25% jitter
+- Stale stream threshold: 75s (2.5 heartbeats)
 
 ## Performance Considerations
 

--- a/src/app/(dashboard)/conversations/[agentName]/[activationName]/page.tsx
+++ b/src/app/(dashboard)/conversations/[agentName]/[activationName]/page.tsx
@@ -12,12 +12,24 @@ import { toast } from 'sonner';
 import { Message, Topic } from '@/types/conversation';
 import { useActivations, useTopics, useConversationState, useAgentHeartbeat } from '../../hooks';
 import { useParticipantLayout } from '@/contexts/participant-layout-context';
-import { getTopicParam, mapXiansMessageToMessage, sanitizeTopicDisplayName } from '../../utils';
+import {
+  getTopicParam,
+  mapXiansMessageToMessage,
+  mergeMessagesById,
+  sanitizeTopicDisplayName,
+} from '../../utils';
 import { MessageStatesMap, TopicMessageState } from '../../types';
 import type { FileUploadPayload } from '@/components/features/conversations';
 import type { XiansMessage } from '@/lib/xians/types';
 import { ConversationView } from '../../_components';
 import { ParticipantMenuBar } from './_components';
+
+/** Page size for the paginated message history (initial load and "load more"). */
+const MESSAGE_PAGE_SIZE = 10;
+/** A backfill after an outage reaches back further than one page. */
+const MESSAGE_SYNC_SIZE = 30;
+/** How often to poll history while the live stream is down. */
+const OFFLINE_POLL_INTERVAL_MS = 10000;
 
 /**
  * Conversation Page
@@ -86,6 +98,7 @@ function ConversationContent() {
     unreadCounts,
     handleIncomingMessage,
     updateTopicMessages,
+    mergeTopicMessages,
     addMessageToTopic,
     applyMessageFeedback,
   } = useConversationState({
@@ -131,19 +144,129 @@ function ConversationContent() {
     return () => { cancelled = true; };
   }, [agentName, currentTenantId, session?.user?.email]);
 
+  // Pull the latest history for a topic and merge it into what's on screen.
+  // The SSE stream replays nothing, so any reply published while it was down is
+  // only recoverable from history.
+  const syncingTopicsRef = useRef<Set<string>>(new Set());
+  const syncTopicMessages = useCallback(async (topicId: string) => {
+    if (!currentTenantId || !agentName || !activationName || !topicId) {
+      return;
+    }
+
+    // Reconnect backfill, topic switch and the offline poll can all fire at once;
+    // one request per topic at a time is enough.
+    if (syncingTopicsRef.current.has(topicId)) {
+      return;
+    }
+    syncingTopicsRef.current.add(topicId);
+
+    try {
+      const queryParams = new URLSearchParams({
+        agentName,
+        activationName,
+        topic: getTopicParam(topicId),
+        page: '1',
+        pageSize: String(MESSAGE_SYNC_SIZE),
+        chatOnly: 'false',
+        sortOrder: 'desc',
+      });
+
+      const response = await fetch(`/api/messaging/history?${queryParams.toString()}`);
+      if (!response.ok) {
+        return;
+      }
+
+      const data = await response.json();
+      if (!Array.isArray(data) || data.length === 0) {
+        return;
+      }
+
+      const latest: Message[] = data
+        .map((row: XiansMessage) => mapXiansMessageToMessage(row))
+        .reverse();
+
+      setMessageStates(prev => {
+        const state = prev[topicId];
+        if (!state) return prev;
+
+        const messages = mergeMessagesById(state.messages, latest);
+        const unchanged =
+          messages.length === state.messages.length &&
+          messages.every((m, i) => m === state.messages[i]);
+        if (unchanged) return prev;
+
+        return {
+          ...prev,
+          [topicId]: {
+            ...state,
+            messages,
+            // A sync spans several pages, so leaving the cursor behind would make
+            // "load more" refetch rows that are already on screen.
+            page: Math.max(state.page, Math.ceil(latest.length / MESSAGE_PAGE_SIZE)),
+          },
+        };
+      });
+
+      mergeTopicMessages(topicId, latest);
+    } catch (error) {
+      console.warn('[ConversationPage] Failed to sync messages:', error);
+    } finally {
+      syncingTopicsRef.current.delete(topicId);
+    }
+  }, [currentTenantId, agentName, activationName, mergeTopicMessages]);
+
+  // Keep the topic in a ref so the reconnect handler stays stable — passing an
+  // unstable callback into the listener is fine (it stores it in a ref), but the
+  // polling fallback below re-subscribes on every change.
+  const selectedTopicIdRef = useRef(selectedTopicId);
+  useEffect(() => {
+    selectedTopicIdRef.current = selectedTopicId;
+  }, [selectedTopicId]);
+
+  // Messages are fetched once per topic and then cached, so a topic that received
+  // messages while the stream was down would stay stale on re-entry.
+  const messageStatesRef = useRef(messageStates);
+  useEffect(() => {
+    messageStatesRef.current = messageStates;
+  }, [messageStates]);
+
+  useEffect(() => {
+    // Topics without cached state are handled by the initial fetch below.
+    if (selectedTopicId && messageStatesRef.current[selectedTopicId]) {
+      syncTopicMessages(selectedTopicId);
+    }
+  }, [selectedTopicId, syncTopicMessages]);
+
+  // SSE reconnect handler - backfill whatever the dropped stream missed
+  const handleSSEReconnect = useCallback(() => {
+    const topicId = selectedTopicIdRef.current;
+    console.log('[SSE] Reconnected, backfilling missed messages for topic:', topicId);
+    if (topicId) {
+      syncTopicMessages(topicId);
+    }
+  }, [syncTopicMessages]);
+
+  // Warn once per outage - the listener retries on its own, so a toast per
+  // failed attempt would just stack up.
+  const hasWarnedAboutSSERef = useRef(false);
+
   // SSE error handler
   const handleSSEError = useCallback((error: Error) => {
-    console.error('[SSE] Connection error:', error.message);
-    if (error.message.includes('Failed to establish SSE connection')) {
-      toast.error('Real-time connection failed', {
-        description: 'Messages may not update automatically. Try refreshing the page.',
-        duration: 5000,
-      });
+    console.warn('[SSE] Connection error:', error.message);
+    const isConnectionError = error.message.includes('SSE connection');
+    if (!isConnectionError || hasWarnedAboutSSERef.current) {
+      return;
     }
+    hasWarnedAboutSSERef.current = true;
+    toast.error('Real-time connection lost', {
+      description: 'Reconnecting… replies will keep arriving, just a little slower.',
+      duration: 5000,
+    });
   }, []);
 
   // SSE connect handler
   const handleSSEConnect = useCallback(() => {
+    hasWarnedAboutSSERef.current = false;
     console.log('[SSE] Real-time connection established');
   }, []);
 
@@ -159,7 +282,13 @@ function ConversationContent() {
   const isActivationActive = selectedActivation?.status === 'active';
 
   // Set up SSE connection - only for active activations
-  const { isConnected, error: sseError, maxReconnectAttemptsReached } = useMessageListener({
+  const {
+    isConnected,
+    error: sseError,
+    maxReconnectAttemptsReached,
+    hasEverConnected,
+    ensureConnected: ensureMessageStreamConnected,
+  } = useMessageListener({
     tenantId: currentTenantId,
     agentName,
     activationName,
@@ -168,7 +297,24 @@ function ConversationContent() {
     onError: handleSSEError,
     onConnect: handleSSEConnect,
     onDisconnect: handleSSEDisconnect,
+    onReconnect: handleSSEReconnect,
   });
+
+  // While the stream is down, poll history so replies still show up instead of
+  // silently waiting for a connection that may never come back.
+  useEffect(() => {
+    if (isConnected || !selectedTopicId || !isActivationActive) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        syncTopicMessages(selectedTopicId);
+      }
+    }, OFFLINE_POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [isConnected, selectedTopicId, isActivationActive, syncTopicMessages]);
 
   // Check agent worker liveness when activation is opened (for Live tag vs warning)
   const {
@@ -184,9 +330,11 @@ function ConversationContent() {
     enabled: !!(currentTenantId && agentName && activationName),
   });
 
-  // Redirect to server unavailable page if max reconnection attempts reached
+  // Redirect to the server unavailable page only when the stream never came up.
+  // Once it has worked, a drop is handled by the background retries plus polling,
+  // so throwing the user out of a live conversation would do more harm than good.
   useEffect(() => {
-    if (maxReconnectAttemptsReached) {
+    if (maxReconnectAttemptsReached && !hasEverConnected) {
       const currentUrl = `/conversations/${encodeURIComponent(agentName)}/${encodeURIComponent(activationName)}?${searchParams.toString()}`;
       const errorMessage = sseError?.message || 'Failed to establish connection to the real-time messaging server after multiple attempts';
       const urlParams = new URLSearchParams({
@@ -195,7 +343,7 @@ function ConversationContent() {
       });
       router.push(`/server-unavailable?${urlParams.toString()}`);
     }
-  }, [maxReconnectAttemptsReached, sseError, searchParams, router, agentName, activationName]);
+  }, [maxReconnectAttemptsReached, hasEverConnected, sseError, searchParams, router, agentName, activationName]);
 
   // Handle activation change (navigate to different agent/activation)
   const handleActivationChange = useCallback((newActivationName: string, newAgentName: string) => {
@@ -437,7 +585,7 @@ function ConversationContent() {
           activationName,
           topic: topicParamValue,
           page: '1',
-          pageSize: '10',
+          pageSize: String(MESSAGE_PAGE_SIZE),
           chatOnly: 'false',
           sortOrder: 'desc',
         });
@@ -467,7 +615,7 @@ function ConversationContent() {
             messages,
             isLoading: false,
             isLoadingMore: false,
-            hasMore: data.length === 10,
+            hasMore: data.length === MESSAGE_PAGE_SIZE,
             page: 1,
           },
         }));
@@ -520,6 +668,11 @@ function ConversationContent() {
     }
 
     notifyHeartbeatActivity();
+
+    // The reply comes back over SSE, so make sure the stream is alive before the
+    // agent answers rather than waiting out the current backoff. A handshake
+    // already in flight is left alone.
+    ensureMessageStreamConnected();
 
     try {
       const topicParamValue = topicId === 'general-discussions' ? undefined : topicId;
@@ -607,7 +760,14 @@ function ConversationContent() {
       console.error('[ConversationPage] Error sending message:', error);
       showErrorToast(error, hasFiles ? 'Failed to upload files' : 'Failed to send message');
     }
-  }, [currentTenantId, agentName, activationName, addMessageToTopic, notifyHeartbeatActivity]);
+  }, [
+    currentTenantId,
+    agentName,
+    activationName,
+    addMessageToTopic,
+    notifyHeartbeatActivity,
+    ensureMessageStreamConnected,
+  ]);
 
   // Handle loading more messages
   const handleLoadMoreMessages = useCallback(async () => {
@@ -637,7 +797,7 @@ function ConversationContent() {
         activationName,
         topic: topicParamValue,
         page: nextPage.toString(),
-        pageSize: '10',
+        pageSize: String(MESSAGE_PAGE_SIZE),
         chatOnly: 'false',
         sortOrder: 'desc',
       });
@@ -673,12 +833,15 @@ function ConversationContent() {
           messages: updatedMessages,
           isLoading: false,
           isLoadingMore: false,
-          hasMore: data.length === 10,
+          hasMore: data.length === MESSAGE_PAGE_SIZE,
           page: nextPage,
         },
       }));
 
-      updateTopicMessages(selectedTopicId, updatedMessages);
+      // Merge rather than replace: live SSE messages only ever land in the
+      // conversation, so overwriting it here would drop everything received
+      // since the last history fetch.
+      mergeTopicMessages(selectedTopicId, updatedMessages);
 
       console.log(`[ConversationPage] Loaded ${uniqueNewMessages.length} more messages for topic:`, selectedTopicId);
     } catch (error) {
@@ -692,7 +855,7 @@ function ConversationContent() {
         },
       }));
     }
-  }, [currentTenantId, agentName, activationName, selectedTopicId, session?.user?.email, messageStates, updateTopicMessages]);
+  }, [currentTenantId, agentName, activationName, selectedTopicId, session?.user?.email, messageStates, mergeTopicMessages]);
 
   const handleMessageFeedbackSubmitted = useCallback(
     (messageId: string, feedback: NonNullable<Message['feedback']>) => {

--- a/src/app/(dashboard)/conversations/hooks/use-conversation-state.ts
+++ b/src/app/(dashboard)/conversations/hooks/use-conversation-state.ts
@@ -2,7 +2,11 @@ import { useState, useCallback, useEffect } from 'react';
 import { Conversation, Topic, Message } from '@/types/conversation';
 import { XiansMessage } from '@/lib/xians/types';
 import { toast } from 'sonner';
-import { mapXiansMessageToMessage, getBackgroundTopicToastDescription } from '../utils';
+import {
+  mapXiansMessageToMessage,
+  getBackgroundTopicToastDescription,
+  mergeMessagesById,
+} from '../utils';
 
 interface UseConversationStateParams {
   tenantId: string;
@@ -97,6 +101,10 @@ export function useConversationState({
 
       const updatedTopics = prev.topics.map((topic) => {
         if (topic.id === topicId) {
+          // A backfill after an SSE drop can race the live event for the same message.
+          if (topic.messages.some((m) => m.id === message.id)) {
+            return topic;
+          }
           return {
             ...topic,
             messages: [...topic.messages, message],
@@ -139,6 +147,40 @@ export function useConversationState({
           return { ...topic, messages };
         }
         return topic;
+      });
+
+      return {
+        ...prev,
+        topics: updatedTopics,
+      };
+    });
+  }, []);
+
+  /**
+   * Merge fetched history into a topic without dropping messages that only exist
+   * locally (optimistic sends, live SSE events). Used to recover messages that
+   * were published while the stream was down.
+   */
+  const mergeTopicMessages = useCallback((topicId: string, incoming: Message[]) => {
+    setConversation((prev) => {
+      if (!prev) return null;
+
+      const updatedTopics = prev.topics.map((topic) => {
+        if (topic.id !== topicId) return topic;
+
+        // Compare identity, not length: the merge both drops optimistic rows and
+        // adds server rows, so a length check misses a one-for-one swap.
+        const messages = mergeMessagesById(topic.messages, incoming);
+        const unchanged =
+          messages.length === topic.messages.length &&
+          messages.every((m, i) => m === topic.messages[i]);
+        if (unchanged) return topic;
+
+        return {
+          ...topic,
+          messages,
+          lastMessageAt: messages[messages.length - 1]?.timestamp ?? topic.lastMessageAt,
+        };
       });
 
       return {
@@ -199,6 +241,7 @@ export function useConversationState({
     unreadCounts,
     handleIncomingMessage,
     updateTopicMessages,
+    mergeTopicMessages,
     addMessageToTopic,
     applyMessageFeedback,
   };

--- a/src/app/(dashboard)/conversations/utils/index.ts
+++ b/src/app/(dashboard)/conversations/utils/index.ts
@@ -165,6 +165,48 @@ export function mapXiansMessageToMessage(xiansMsg: XiansMessage): Message {
 }
 
 /**
+ * Merge freshly fetched history into the messages already on screen, keeping
+ * chronological order. Used to backfill replies that arrived while the SSE
+ * stream was down.
+ *
+ * Server rows win over anything already held under the same id, and an
+ * optimistic `temp-` row is dropped once the server echoes back the same
+ * user message.
+ */
+export function mergeMessagesById(existing: Message[], incoming: Message[]): Message[] {
+  if (incoming.length === 0) return existing;
+
+  const incomingIds = new Set(incoming.map((m) => m.id));
+  const existingIds = new Set(existing.map((m) => m.id));
+
+  // Only a server row we haven't seen before can stand in for an optimistic row,
+  // and it can stand in for exactly one - sending the same text twice must not
+  // collapse into a single bubble.
+  const unmatchedUserContent = new Map<string, number>();
+  for (const m of incoming) {
+    if (m.role !== 'user' || existingIds.has(m.id)) continue;
+    const key = m.content.trim();
+    unmatchedUserContent.set(key, (unmatchedUserContent.get(key) ?? 0) + 1);
+  }
+
+  const kept = existing.filter((m) => {
+    if (incomingIds.has(m.id)) return false;
+    if (!m.id.startsWith('temp-')) return true;
+
+    const key = m.content.trim();
+    const remaining = unmatchedUserContent.get(key) ?? 0;
+    if (remaining === 0) return true;
+
+    unmatchedUserContent.set(key, remaining - 1);
+    return false;
+  });
+
+  return [...kept, ...incoming].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  );
+}
+
+/**
  * Toast body for a background-topic SSE message.
  * File messages with no caption fall back to the attachment name(s) instead of an empty string.
  */

--- a/src/app/api/messaging/listen/route.ts
+++ b/src/app/api/messaging/listen/route.ts
@@ -49,15 +49,27 @@ export async function GET(request: NextRequest) {
 
       const xiansUrl = `${xiansBaseUrl}/api/v1/admin/tenants/${tenantId}/messaging/listen?${queryParams.toString()}`
 
-      const xiansResponse = await fetch(xiansUrl, {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${xiansApiKey}`,
-          Accept: 'text/event-stream',
-          'Cache-Control': 'no-cache',
-          Connection: 'keep-alive',
-        },
-      })
+      let xiansResponse: Response
+      try {
+        // Forwarding the abort signal tears down the upstream stream when the
+        // browser closes the EventSource, instead of leaking one connection per
+        // reconnect.
+        xiansResponse = await fetch(xiansUrl, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${xiansApiKey}`,
+            Accept: 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            Connection: 'keep-alive',
+          },
+          signal: req.signal,
+        })
+      } catch (error) {
+        if (req.signal.aborted) {
+          return new Response(null, { status: 499 })
+        }
+        throw error
+      }
 
       if (!xiansResponse.ok) {
         return new Response(

--- a/src/hooks/use-message-listener.ts
+++ b/src/hooks/use-message-listener.ts
@@ -12,14 +12,37 @@ export interface UseMessageListenerParams {
   onError?: (error: Error) => void;
   onConnect?: () => void;
   onDisconnect?: () => void;
+  /**
+   * Fired when the stream is re-established after a drop. Messages published while
+   * the stream was down are never replayed, so callers must backfill from history.
+   */
+  onReconnect?: () => void;
 }
 
 export interface UseMessageListenerReturn {
   isConnected: boolean;
   error: Error | null;
   reconnect: () => void;
+  /** Reconnect only if the stream is actually down; a handshake in progress is left alone. */
+  ensureConnected: () => void;
   maxReconnectAttemptsReached: boolean;
+  /** True once a stream has been established at least once for these parameters. */
+  hasEverConnected: boolean;
 }
+
+const HEARTBEAT_SECONDS = 30;
+/** Silence longer than a couple of heartbeats means the stream is dead, whatever readyState says. */
+const STALE_STREAM_MS = HEARTBEAT_SECONDS * 1000 * 2.5;
+const WATCHDOG_INTERVAL_MS = 10_000;
+const MAX_RECONNECT_ATTEMPTS = 6;
+const BASE_RECONNECT_DELAY_MS = 1000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+/** Slow retry cadence once the backoff ladder is exhausted, or while the browser reports itself offline. */
+const IDLE_RETRY_DELAY_MS = 60_000;
+/** Floor between forced reconnects, so repeatedly focusing the tab can't hammer a down server. */
+const MIN_FORCED_RECONNECT_INTERVAL_MS = 10_000;
+
+const MESSAGE_EVENT_TYPES = ['Chat', 'Reasoning', 'Tool', 'Data', 'File'] as const;
 
 /**
  * Custom hook to manage SSE connection for real-time message listening
@@ -39,22 +62,38 @@ export function useMessageListener(
     onError,
     onConnect,
     onDisconnect,
+    onReconnect,
   } = params;
+
+  // Connection outcomes are tracked per parameter set rather than as plain
+  // booleans, so switching agent/activation implicitly clears stale state.
+  const connectionKey = `${tenantId}|${agentName}|${activationName}`;
 
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const [maxReconnectAttemptsReached, setMaxReconnectAttemptsReached] = useState(false);
+  const [connectedKey, setConnectedKey] = useState<string | null>(null);
+  const [failedKey, setFailedKey] = useState<string | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const reconnectAttemptsRef = useRef(0);
-  const maxReconnectAttempts = 5;
-  const baseReconnectDelay = 1000; // Start with 1 second
+  const isConnectedRef = useRef(false);
+  const hasEverConnectedRef = useRef(false);
+  const lastConnectionKeyRef = useRef<string | null>(null);
+  // Timestamp of the last event received on the stream (heartbeats included).
+  const lastEventAtRef = useRef(0);
+  const lastConnectAttemptAtRef = useRef(0);
+  // Latest connect(), so watchdog/network listeners never call a stale closure.
+  const connectRef = useRef<() => void>(() => {});
+
+  const hasEverConnected = connectedKey === connectionKey;
+  const maxReconnectAttemptsReached = failedKey === connectionKey;
 
   // Store callbacks in refs to prevent reconnections when they change
   const onMessageRef = useRef(onMessage);
   const onErrorRef = useRef(onError);
   const onConnectRef = useRef(onConnect);
   const onDisconnectRef = useRef(onDisconnect);
+  const onReconnectRef = useRef(onReconnect);
 
   // Update refs when callbacks change
   useEffect(() => {
@@ -62,13 +101,15 @@ export function useMessageListener(
     onErrorRef.current = onError;
     onConnectRef.current = onConnect;
     onDisconnectRef.current = onDisconnect;
-  }, [onMessage, onError, onConnect, onDisconnect]);
+    onReconnectRef.current = onReconnect;
+  }, [onMessage, onError, onConnect, onDisconnect, onReconnect]);
 
   const disconnect = useCallback(() => {
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
       eventSourceRef.current = null;
       setIsConnected(false);
+      isConnectedRef.current = false;
       onDisconnectRef.current?.();
     }
 
@@ -76,6 +117,53 @@ export function useMessageListener(
       clearTimeout(reconnectTimeoutRef.current);
       reconnectTimeoutRef.current = null;
     }
+  }, []);
+
+  const scheduleReconnect = useCallback((key: string) => {
+    if (reconnectTimeoutRef.current) {
+      return;
+    }
+
+    // Retrying at full speed while the device is offline just burns attempts.
+    // `navigator.onLine` is only a hint though (it reads false on some VPN and
+    // captive-portal setups), so keep a slow retry armed rather than relying
+    // solely on the `online` event.
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+      console.log('[SSE] Offline, retrying slowly until the network is back');
+      reconnectTimeoutRef.current = setTimeout(() => {
+        reconnectTimeoutRef.current = null;
+        connectRef.current();
+      }, IDLE_RETRY_DELAY_MS);
+      return;
+    }
+
+    if (reconnectAttemptsRef.current >= MAX_RECONNECT_ATTEMPTS) {
+      console.error('[SSE] Max reconnection attempts reached, retrying slowly');
+      setFailedKey(key);
+      onDisconnectRef.current?.();
+      reconnectTimeoutRef.current = setTimeout(() => {
+        reconnectTimeoutRef.current = null;
+        reconnectAttemptsRef.current = 0;
+        connectRef.current();
+      }, IDLE_RETRY_DELAY_MS);
+      return;
+    }
+
+    const backoff = Math.min(
+      BASE_RECONNECT_DELAY_MS * Math.pow(2, reconnectAttemptsRef.current),
+      MAX_RECONNECT_DELAY_MS
+    );
+    // Jitter avoids every open tab reconnecting in lockstep after a server blip.
+    const delay = Math.round(backoff + Math.random() * backoff * 0.25);
+
+    console.log(
+      `[SSE] Reconnecting in ${delay}ms (attempt ${reconnectAttemptsRef.current + 1}/${MAX_RECONNECT_ATTEMPTS})`
+    );
+    reconnectAttemptsRef.current++;
+    reconnectTimeoutRef.current = setTimeout(() => {
+      reconnectTimeoutRef.current = null;
+      connectRef.current();
+    }, delay);
   }, []);
 
   const connect = useCallback(() => {
@@ -99,37 +187,60 @@ export function useMessageListener(
     // Disconnect existing connection (cleanup)
     disconnect();
 
+    // A different agent/activation is a fresh connection, not a reconnection.
+    if (lastConnectionKeyRef.current !== connectionKey) {
+      lastConnectionKeyRef.current = connectionKey;
+      hasEverConnectedRef.current = false;
+      reconnectAttemptsRef.current = 0;
+    }
+
     try {
       // Build query parameters
       // participantId is now obtained from session on the backend for security
       const queryParams = new URLSearchParams({
         agentName,
         activationName,
-        heartbeatSeconds: '60',
+        heartbeatSeconds: String(HEARTBEAT_SECONDS),
       });
 
       const url = `/api/messaging/listen?${queryParams.toString()}`;
       
       console.log('[SSE] Attempting to connect to:', url);
-      
+
+      lastEventAtRef.current = Date.now();
+      lastConnectAttemptAtRef.current = Date.now();
       const eventSource = new EventSource(url);
       eventSourceRef.current = eventSource;
-      
-      // Log initial state
-      console.log('[SSE] EventSource created with readyState:', eventSource.readyState);
+
+      // Anything arriving on the wire counts as liveness for the watchdog,
+      // including untyped events we don't otherwise handle.
+      eventSource.onmessage = () => {
+        lastEventAtRef.current = Date.now();
+      };
 
       // Handle connection open
       eventSource.addEventListener('open', () => {
         console.log('[SSE] Connection established');
+        lastEventAtRef.current = Date.now();
         setIsConnected(true);
         setError(null);
-        setMaxReconnectAttemptsReached(false);
+        setFailedKey((prev) => (prev === connectionKey ? null : prev));
+        setConnectedKey(connectionKey);
         reconnectAttemptsRef.current = 0;
+        isConnectedRef.current = true;
         onConnectRef.current?.();
+
+        if (hasEverConnectedRef.current) {
+          // Nothing is replayed on a new stream, so the caller has to backfill.
+          onReconnectRef.current?.();
+        } else {
+          hasEverConnectedRef.current = true;
+        }
       });
 
       // Handle 'connected' event (initial connection confirmation from Xians)
       eventSource.addEventListener('connected', (event) => {
+        lastEventAtRef.current = Date.now();
         try {
           const data = JSON.parse(event.data);
           console.log('[SSE] Connected to thread:', data.threadId);
@@ -138,89 +249,28 @@ export function useMessageListener(
         }
       });
 
-      // Handle 'Chat' event type (chat messages from agent/user)
-      eventSource.addEventListener('Chat', (event) => {
-        try {
-          const message = JSON.parse(event.data) as XiansMessage;
-          
-          if (onMessageRef.current) {
-            onMessageRef.current(message);
+      // Chat/Reasoning/Tool/Data/File all carry a XiansMessage payload.
+      // File matters for SendFileAsync replies, which would otherwise stay
+      // invisible until the user refreshes history.
+      for (const eventType of MESSAGE_EVENT_TYPES) {
+        eventSource.addEventListener(eventType, (event) => {
+          lastEventAtRef.current = Date.now();
+          try {
+            const message = JSON.parse(event.data) as XiansMessage;
+            onMessageRef.current?.(message);
+          } catch (err) {
+            console.error(`[SSE] Error parsing ${eventType} message:`, err);
+            const parseError =
+              err instanceof Error ? err : new Error(`Failed to parse ${eventType} message`);
+            setError(parseError);
+            onErrorRef.current?.(parseError);
           }
-        } catch (err) {
-          console.error('[SSE] Error parsing Chat message:', err);
-          const parseError = err instanceof Error ? err : new Error('Failed to parse Chat message');
-          setError(parseError);
-          onErrorRef.current?.(parseError);
-        }
-      });
-
-      // Handle 'Reasoning' event type (agent thinking/reasoning steps)
-      eventSource.addEventListener('Reasoning', (event) => {
-        try {
-          const message = JSON.parse(event.data) as XiansMessage;
-          
-          if (onMessageRef.current) {
-            onMessageRef.current(message);
-          }
-        } catch (err) {
-          console.error('[SSE] Error parsing Reasoning message:', err);
-          const parseError = err instanceof Error ? err : new Error('Failed to parse Reasoning message');
-          setError(parseError);
-          onErrorRef.current?.(parseError);
-        }
-      });
-
-      // Handle 'Tool' event type (agent tool execution steps)
-      eventSource.addEventListener('Tool', (event) => {
-        try {
-          const message = JSON.parse(event.data) as XiansMessage;
-          
-          if (onMessageRef.current) {
-            onMessageRef.current(message);
-          }
-        } catch (err) {
-          console.error('[SSE] Error parsing Tool message:', err);
-          const parseError = err instanceof Error ? err : new Error('Failed to parse Tool message');
-          setError(parseError);
-          onErrorRef.current?.(parseError);
-        }
-      });
-
-      // Handle 'Data' event type (structured data messages)
-      eventSource.addEventListener('Data', (event) => {
-        try {
-          const message = JSON.parse(event.data) as XiansMessage;
-          
-          if (onMessageRef.current) {
-            onMessageRef.current(message);
-          }
-        } catch (err) {
-          console.error('[SSE] Error parsing Data message:', err);
-          const parseError = err instanceof Error ? err : new Error('Failed to parse Data message');
-          setError(parseError);
-          onErrorRef.current?.(parseError);
-        }
-      });
-
-      // Handle 'File' event type (agent/user file attachments). Without this,
-      // SendFileAsync replies stay invisible until the user refreshes history.
-      eventSource.addEventListener('File', (event) => {
-        try {
-          const message = JSON.parse(event.data) as XiansMessage;
-
-          if (onMessageRef.current) {
-            onMessageRef.current(message);
-          }
-        } catch (err) {
-          console.error('[SSE] Error parsing File message:', err);
-          const parseError = err instanceof Error ? err : new Error('Failed to parse File message');
-          setError(parseError);
-          onErrorRef.current?.(parseError);
-        }
-      });
+        });
+      }
 
       // Handle heartbeat events (keep-alive)
       eventSource.addEventListener('heartbeat', (event) => {
+        lastEventAtRef.current = Date.now();
         try {
           const data = JSON.parse(event.data);
           // Heartbeats are silent - only log if there's an issue
@@ -233,92 +283,164 @@ export function useMessageListener(
       });
 
       // Handle errors
-      eventSource.addEventListener('error', (event) => {
+      eventSource.addEventListener('error', () => {
+        const wasConnected = isConnectedRef.current;
         const readyState = eventSource.readyState;
-        const readyStateText = readyState === 0 ? 'CONNECTING' : readyState === 1 ? 'OPEN' : 'CLOSED';
-        
-        console.error('[SSE] Connection error', {
+
+        console.warn('[SSE] Connection error', {
           readyState,
-          readyStateText,
-          eventType: event.type,
-          timeStamp: event.timeStamp,
-          wasConnected: isConnected,
+          readyStateText: readyState === 0 ? 'CONNECTING' : readyState === 1 ? 'OPEN' : 'CLOSED',
+          wasConnected,
+          url,
         });
-        
-        // If we were previously connected and got an error, this is likely a transient network issue
-        // If we never connected (readyState === 0), this could be a CORS, auth, or server issue
-        const errorMessage = readyState === 0 
-          ? 'Failed to establish SSE connection. Check server availability and CORS settings.'
-          : 'SSE connection lost. Attempting to reconnect...';
-        
-        const connectionError = new Error(errorMessage);
+
+        // A drop after a healthy stream is usually a transient network/proxy issue.
+        // Failing before the stream ever opened points at auth, CORS or the server.
+        const connectionError = new Error(
+          wasConnected
+            ? 'SSE connection lost. Attempting to reconnect...'
+            : 'Failed to establish SSE connection. Check server availability and CORS settings.'
+        );
         setError(connectionError);
         setIsConnected(false);
+        isConnectedRef.current = false;
         onErrorRef.current?.(connectionError);
 
-        // Close the connection
+        // Close the connection: the browser's own retry has no backoff and would
+        // race with ours.
         eventSource.close();
-        eventSourceRef.current = null;
-
-        // Only auto-reconnect if we had successfully connected before, or haven't exceeded attempts
-        const shouldReconnect = reconnectAttemptsRef.current < maxReconnectAttempts;
-        
-        if (shouldReconnect) {
-          const delay = baseReconnectDelay * Math.pow(2, reconnectAttemptsRef.current);
-          console.log(`[SSE] Reconnecting in ${delay}ms (attempt ${reconnectAttemptsRef.current + 1}/${maxReconnectAttempts})`);
-          
-          reconnectAttemptsRef.current++;
-          reconnectTimeoutRef.current = setTimeout(() => {
-            connect();
-          }, delay);
-        } else {
-          console.error('[SSE] Max reconnection attempts reached. Please check:', {
-            url,
-            tenantId,
-            agentName,
-            activationName,
-          });
-          setMaxReconnectAttemptsReached(true);
-          onDisconnectRef.current?.();
+        if (eventSourceRef.current === eventSource) {
+          eventSourceRef.current = null;
         }
+
+        scheduleReconnect(connectionKey);
       });
     } catch (err) {
       console.error('[SSE] Error creating EventSource:', err);
       const connectionError = err instanceof Error ? err : new Error('Failed to create SSE connection');
       setError(connectionError);
+      setIsConnected(false);
+      isConnectedRef.current = false;
       onErrorRef.current?.(connectionError);
+      scheduleReconnect(connectionKey);
     }
   }, [
     tenantId,
     agentName,
     activationName,
+    connectionKey,
     enabled,
     disconnect,
+    scheduleReconnect,
   ]);
 
-  const reconnect = useCallback(() => {
-    reconnectAttemptsRef.current = 0; // Reset attempts for manual reconnect
-    setMaxReconnectAttemptsReached(false); // Reset max attempts flag
-    connect();
+  useEffect(() => {
+    connectRef.current = connect;
   }, [connect]);
+
+  const forceReconnect = useCallback((reason: string, { resetAttempts = false } = {}) => {
+    console.log(`[SSE] Reconnecting now (${reason})`);
+    // Only a deliberate user action clears the backoff ladder. Automatic triggers
+    // keep counting, otherwise a user alt-tabbing during an outage would reset the
+    // ladder forever and `maxReconnectAttemptsReached` would never be reached.
+    if (resetAttempts) {
+      reconnectAttemptsRef.current = 0;
+      setFailedKey(null);
+    }
+    disconnect();
+    connectRef.current();
+  }, [disconnect]);
+
+  const reconnect = useCallback(() => {
+    forceReconnect('manual reconnect', { resetAttempts: true });
+  }, [forceReconnect]);
+
+  /**
+   * Revive the stream only when it is genuinely down. Unlike `reconnect`, a
+   * handshake still in flight is left to finish - tearing it down would restart
+   * the wait and, on a first connection, skip the `onReconnect` backfill.
+   */
+  const ensureConnected = useCallback(() => {
+    const readyState = eventSourceRef.current?.readyState;
+    if (readyState === EventSource.OPEN || readyState === EventSource.CONNECTING) {
+      return;
+    }
+    forceReconnect('send while disconnected', { resetAttempts: true });
+  }, [forceReconnect]);
 
   // Connect on mount or when parameters change
   useEffect(() => {
-    if (enabled && tenantId && agentName && activationName) {
-      connect();
+    if (!enabled || !tenantId || !agentName || !activationName) {
+      return;
     }
 
-    // Cleanup on unmount
+    // Opening the stream is deferred so it happens outside the commit phase.
+    const startTimeout = setTimeout(() => connectRef.current(), 0);
+
     return () => {
+      clearTimeout(startTimeout);
       disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, tenantId, agentName, activationName]);
 
+  // A dropped stream does not always surface as an `error` event: after a sleep/wake
+  // or a silently killed proxy connection the EventSource can sit in OPEN forever.
+  // Heartbeats let us notice the silence and rebuild the stream.
+  useEffect(() => {
+    if (!enabled || !tenantId || !agentName || !activationName) {
+      return;
+    }
+
+    const ensureAlive = (reason: string, { ignorePending = false } = {}) => {
+      if (reconnectTimeoutRef.current && !ignorePending) {
+        return;
+      }
+      if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+        return;
+      }
+
+      const readyState = eventSourceRef.current?.readyState;
+      const isLive = readyState === EventSource.OPEN || readyState === EventSource.CONNECTING;
+      const isStale = Date.now() - lastEventAtRef.current > STALE_STREAM_MS;
+      if (isLive && !isStale) {
+        return;
+      }
+
+      if (Date.now() - lastConnectAttemptAtRef.current < MIN_FORCED_RECONNECT_INTERVAL_MS) {
+        return;
+      }
+
+      forceReconnect(reason);
+    };
+
+    const watchdog = setInterval(() => {
+      ensureAlive(`no events for over ${Math.round(STALE_STREAM_MS / 1000)}s`);
+    }, WATCHDOG_INTERVAL_MS);
+
+    const handleOnline = () => ensureAlive('network came back', { ignorePending: true });
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        ensureAlive('tab became visible', { ignorePending: true });
+      }
+    };
+
+    window.addEventListener('online', handleOnline);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      clearInterval(watchdog);
+      window.removeEventListener('online', handleOnline);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [enabled, tenantId, agentName, activationName, forceReconnect]);
+
   return {
     isConnected,
     error,
     reconnect,
+    ensureConnected,
     maxReconnectAttemptsReached,
+    hasEverConnected,
   };
 }


### PR DESCRIPTION
## Problem

When the SSE message stream errored, the user's message was sent but the agent's reply never appeared — the exact symptom being reported, alongside `[SSE] Connection error {}` in the console.

Three things were wrong:

1. **Missed messages were unrecoverable.** A new SSE stream replays nothing, so any reply published while the stream was down was lost until a full page reload. Reconnecting alone never fixed this.
2. **Silently dead streams were invisible.** After sleep/wake or a proxy dropping the connection, no `error` event fires and `readyState` stays `OPEN`, so the hook reported itself connected forever.
3. **The client gave up too easily.** Five attempts over ~31s, then a permanent redirect to `/server-unavailable` — even for a conversation that had been working fine a second earlier.

The upstream stream ends on its own every couple of minutes (`GET /api/messaging/listen ... 200 in 2.3min` in local logs), so this was hit routinely.

## Changes

**Reconnection** (`src/hooks/use-message-listener.ts`)
- Exponential backoff capped at 30s with jitter; after the ladder is exhausted it keeps retrying once a minute instead of giving up.
- Heartbeat watchdog rebuilds any stream that has received nothing for 75s, regardless of `readyState`. Heartbeat interval lowered 60s → 30s to stay under typical proxy idle timeouts.
- Reconnects on `online` and `visibilitychange`; throttled and without resetting the backoff ladder, so tab-focusing during an outage can't hammer a down server.
- While offline, retries slowly rather than stopping entirely (`navigator.onLine` is only a hint).
- New `onReconnect` callback and `hasEverConnected` / `ensureConnected` in the return value. `connect` is reached through a ref, fixing a stale-closure bug where the retry timer called an outdated `connect`.

**Recovering missed messages** (conversation page, `use-conversation-state`, `utils`)
- `onReconnect` refetches the topic's history and merges it into what's on screen via a new `mergeMessagesById` helper (dedupes by id, retires optimistic `temp-` rows one-for-one).
- History is polled every 10s while the stream is down, so a reply lands even if the stream never recovers.
- Cached topics re-sync on switch, and sending while disconnected revives the stream immediately (leaving an in-flight handshake alone).

**Other**
- `/server-unavailable` redirect now only fires when the stream never connected at all.
- The connection-lost toast fires once per outage instead of once per retry.
- `/api/messaging/listen` forwards the request abort signal upstream, so each reconnect no longer leaks an upstream connection.
- "Load more" now merges into the conversation instead of replacing it, fixing a pre-existing bug where paging back wiped every live message received since the last history fetch.

## Test plan

- [x] `npx tsc --noEmit` clean; eslint clean on changed files (the remaining `set-state-in-effect` errors are pre-existing)
- [x] `npm run build` passes in a clean worktree
- [x] `mergeMessagesById` verified against: optimistic row replaced by its server echo, the same text sent twice, an echo already on screen, a no-op merge preserving element identity, and a live SSE message surviving a backfill
- [ ] Leave a conversation idle past the stream drop (~2 min), send a message, confirm the reply arrives without a reload
- [ ] Sleep/wake or switch networks mid-conversation, confirm the stream rebuilds and missed messages backfill
- [ ] Upload a file, confirm the optimistic row is replaced by the real one and stays downloadable

Made with [Cursor](https://cursor.com)